### PR TITLE
Add mesh selection

### DIFF
--- a/source/voronoi-fracture.cpp
+++ b/source/voronoi-fracture.cpp
@@ -25,9 +25,8 @@ MStatus VoronoiFracture::doIt(const MArgList& args)
     }
 
     // Use the first kMesh object in the selection
-    MObject component;
     MDagPath node;
-    it.getDagPath(node, component);
+    it.getDagPath(node);
 
     MFnDagNode node_fn(node);
     displayInfo(MString("Fracturing ") + node_fn.name());


### PR DESCRIPTION
Closes #1 

Selects the first polygon mesh (`kMesh`) in the selection and prints its vertices for now.